### PR TITLE
docs: format ARCHAEOLOGY.md (Project Bridge heading + YAML)

### DIFF
--- a/docs/ARCHAEOLOGY.md
+++ b/docs/ARCHAEOLOGY.md
@@ -1,20 +1,33 @@
-**Project_Bridge**
+# Project Bridge
 
-Name: BananaMoon ↔ Quantum Signature Provenance Bridge
-Japanese: バナナムーン＝量子署名 来歴接続橋
+**Name:** BananaMoon ↔ Quantum Signature Provenance Bridge  
+**Japanese:** バナナムーン＝量子署名 来歴接続橋
 
 Purpose:
 
-* Work Origin:
-* Collaborative Trace:
-* AI Interaction:
-* Risky Automation and Preservation Value Separation:
-* Future Work: Trustable Provenance Archaeology
+- Work Origin
+- Collaborative Trace
+- AI Interaction
+- Risky Automation and Preservation Value Separation
+- Future Work: Trustable Provenance Archaeology
 
 ## Timefold Note
 
-This archive moves time in two directions:
-from the future by designing safer workflows;
+This archive moves time in two directions:  
+from the future by designing safer workflows;  
 from the past by preserving fragile traces of co-creation.
 
 Trust is not only a forward-looking concept but also one that involves preserving the past.
+
+```yaml
+next_action:
+  priority_1:
+    target: "docs/ARCHAEOLOGY.md"
+    action: "Markdown見出しとYAMLブロックを整える"
+  priority_2:
+    target: ".github/workflows/たた と なな"
+    action: "移動前に、それぞれの内容をARCHAEOLOGY.mdに記録"
+  priority_3:
+    target: ".github/workflows"
+    action: "最終的にworkflow YAMLだけを残す"
+```


### PR DESCRIPTION
概要：docs/ARCHAEOLOGY.md の見出しおよび YAML ブロックのフォーマットを整備いたしました（Project Bridge セクションを Markdown 見出しへ変換、next_action を YAML ブロックとして追加）。

実施範囲：priority_1 のみを実施いたします。priority_2 および priority_3 の移動および整理につきましては、別途 PR を提出する予定です。

理由：発掘記録の器を安定化させた上で、ワークフローの移動および統合を実施するためです。