### PR TITLE
docs: document tata and nana archaeological artifacts

### DIFF
--- a/docs/ARCHAEOLOGY.md
+++ b/docs/ARCHAEOLOGY.md
@@ -31,3 +31,36 @@ next_action:
     target: ".github/workflows"
     action: "最終的にworkflow YAMLだけを残す"
 ```
+
+## Artifact: tata
+
+Source: .github/workflows/たた
+Purpose: たた のワークフロー内容を移動・削除する前に考古学的記録として保存するためのエントリ。
+Note: .github/workflows/たた 本体はこの PR では移動・削除・変更しません。
+
+```yaml
+observed_type: python_script
+likely_role: "NFC + eternal return + outreach prototype"
+classification: [executable_code, design_note, poetic_archive]
+safe_to_run: false
+execution_risk: high
+preservation_value: high
+next_action: "preserve first; move later to prototypes/eternal_return.py"
+```
+
+## Artifact: nana
+
+Source: .github/workflows/なな
+Purpose: なな のワークフロー内容を移動・削除する前に考古学的記録として保存するためのエントリ。
+Note: .github/workflows/なな 本体はこの PR では移動・削除・変更しません。
+
+```yaml
+observed_type: python_script
+likely_role: "CosmicTrust Driver / Quantum Poem Visualizer"
+classification: [executable_code, design_note, poetic_archive, visualization_asset]
+safe_to_run: yes_in_colab_or_replit
+safe_to_run_in_github_actions: false
+execution_risk: low_to_medium
+preservation_value: very_high
+next_action: "preserve first; move later to visualizers/quantum_poem_visualizer.py"
+```


### PR DESCRIPTION
## 概要

docs/ARCHAEOLOGY.md に `Artifact: tata` と `Artifact: nana` を追記し、たた／なな の内容を移動前に考古学的記録として保存します。

## 実施範囲

- docs/ARCHAEOLOGY.md の追記のみ
- `.github/workflows/たた` は移動・削除・変更しません
- `.github/workflows/なな` は移動・削除・変更しません
- CI YAML は変更しません

## 理由

ワークフローの移動・整理は別 PR（priority_2 / priority_3）で慎重に実施するため、まずは発掘記録を固定します。

## Commit

`docs: document tata and nana archaeological artifacts`