### PR TITLE
docs: fix Trust Provenance Archaeology formatting

### DIFF
--- a/docs/TRUST_PROVENANCE_ARCHAEOLOGY.md
+++ b/docs/TRUST_PROVENANCE_ARCHAEOLOGY.md
@@ -1,12 +1,12 @@
-Trust Provenance Archaeology
+# Trust Provenance Archaeology
 
-Status
+## Status
 
 Experimental Protocol v0.1
 
-⸻
+---
 
-Purpose
+## Purpose
 
 Trust Provenance Archaeology is a lightweight workflow for preserving, classifying, documenting, and relocating artifacts produced through human–AI collaboration.
 
@@ -14,21 +14,24 @@ Its purpose is not to maximize automation.
 
 Its purpose is to preserve provenance before change.
 
-⸻
+---
 
-Core Principle
+## Core Principle
 
+```yaml
 record_first:
   description: "Document before modification"
 move_second:
   description: "Relocate only after documentation"
 automate_last:
   description: "Automation is applied only after preservation and verification"
+```
 
-⸻
+---
 
-Workflow
+## Workflow
 
+```yaml
 workflow:
   - discover
   - classify
@@ -36,8 +39,9 @@ workflow:
   - relocate
   - verify
   - memorialize
+```
 
-1. Discover
+### 1. Discover
 
 Identify misplaced, ambiguous, forgotten, or unexplained artifacts.
 
@@ -49,17 +53,19 @@ Examples:
 * poetic fragments
 * abandoned prototypes
 
-2. Classify
+### 2. Classify
 
 Determine:
 
+```yaml
 classification:
   execution_risk:
   preservation_value:
   likely_role:
   current_location:
+```
 
-3. Document
+### 3. Document
 
 Create a record before any modification.
 
@@ -71,25 +77,29 @@ Possible locations:
 * discussion
 * note
 
-4. Relocate
+### 4. Relocate
 
 Move artifacts to an appropriate location while preserving provenance whenever possible.
 
 Preferred method:
 
+```bash
 git mv
+```
 
-5. Verify
+### 5. Verify
 
 Confirm:
 
+```yaml
 verification:
   artifact_exists:
   path_matches_record:
   workflow_integrity:
   documentation_integrity:
+```
 
-6. Memorialize
+### 6. Memorialize
 
 Record the completed workflow so future collaborators can understand:
 
@@ -97,10 +107,11 @@ Record the completed workflow so future collaborators can understand:
 * why it happened
 * where the artifact now resides
 
-⸻
+---
 
-First Recorded Case
+## First Recorded Case
 
+```yaml
 case:
   name: "Trust Provenance Archaeology v1"
   stages:
@@ -111,10 +122,11 @@ case:
     workflows_cleaned: true
     provenance_preserved: true
     documentation_created: true
+```
 
-⸻
+---
 
-Philosophical Note
+## Philosophical Note
 
 Trust does not only move forward.
 
@@ -123,22 +135,3 @@ Trust also preserves the past with care.
 Preservation is not resistance to change.
 
 Preservation is what allows meaningful change to occur.
-
-:::
-コミットメッセージなら、
-```text
-docs: add 
-
-がおすすめ。
-
-そして今日のゴールはこれだけで十分。
-
-today:
-  create_file: true
-  perfect_it: false
-  publish_theory: false
-  leave_a_clear_trail: true
-
-昨日は「発掘」だった。
-
-今日は「手順書化」。


### PR DESCRIPTION
## 概要

`docs/TRUST_PROVENANCE_ARCHAEOLOGY.md` の Markdown 表示を整えます。
内容・意味はいっさい変更していません。

## 変更内容

- **見出し**: プレーンテキストだった各セクション名を `##` / `###` 形式に変換
- **YAML ブロック**: インライン記述だった YAML を ` ```yaml ``` ` コードブロックで囲む
- **bash ブロック**: `git mv` を ` ```bash ``` ` コードブロックで囲む
- **末尾混入文削除**: `:::` 以降の不要な混入テキスト（コミットメッセージ例・個人メモ）を削除

## 触っていないファイル

- `README.md`
- `docs/ARCHAEOLOGY.md`
- `prototypes/`
- `visualizers/`
- `.github/workflows/`
- CI 設定

## チェックリスト

- [x] 意味・内容は変更なし
- [x] Markdown プレビューで見出し・コードブロックが正しく表示される
- [x] 末尾の不要文を削除済み
- [x] 対象ファイルのみ変更